### PR TITLE
Remove undici shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ import { QueryConfiguration } from "https://deno.land/x/entsoe_api_client/mod.ts
 npm install entsoe-api-client --save
 ```
 
+### Note
+Using an older version of Node.js? Use 0.x versions of this library for fetch compatibility.
 
 ## Documentation
 

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -13,7 +13,6 @@ await build({
   outDir: "./npm",
   shims: {
     deno: "dev",
-    undici: true // Undici is for fetch support in old node versions
   },
   mappings: {
     "https://deno.land/x/zipjs@v2.6.63/index.js": {

--- a/src/query.ts
+++ b/src/query.ts
@@ -256,6 +256,7 @@ const Query = async (securityToken: string, params: QueryParameters): Promise<(P
   const query = ComposeQuery(securityToken, params);
 
   // Construct url and get result
+  // @ts-expect-error fetch is not recognised as a valid global.
   const result = await fetch(`${ENTSOE_ENDPOINT}?${query}`);
 
   // Check for 401
@@ -282,6 +283,9 @@ const Query = async (securityToken: string, params: QueryParameters): Promise<(P
       for (const xmlFileEntry of await zipReader.getEntries()) {
         // Unzip file
         const stringDataWriter = new TextWriter();
+
+        if (typeof xmlFileEntry.getData !== "function") break;
+
         await xmlFileEntry.getData(stringDataWriter);
         const xmlFileData = await stringDataWriter.getData();
 


### PR DESCRIPTION
To enable this package to be used in serverless environments (e.g. Cloudflare Workers) the undici shim needs to be removed. The current LTS and modern versions of Node.js support fetch natively and without flags.

Resolves https://github.com/Hexagon/entsoe-api-client/issues/4

* Run precommit checks
* Added note to README
* Fixed a build error when compiling for npm where TS would complain about unsafe accessing of xmlFileEntry.getData
* Added a ts-expect-error flag before using fetch, I tried to create a fetch.d.ts definition [as proposed here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924#issuecomment-1563621855) but the compiler still complained.